### PR TITLE
Add autodetection of *.ttcn files

### DIFF
--- a/ftdetect/ttcn.vim
+++ b/ftdetect/ttcn.vim
@@ -1,2 +1,2 @@
 " TTCN filetype
-au BufRead,BufNewFile *.ttcn set filetype=ttcn
+au BufRead,BufNewFile *.{ttcn,ttcn3} set filetype=ttcn

--- a/ftdetect/ttcn.vim
+++ b/ftdetect/ttcn.vim
@@ -1,0 +1,2 @@
+" TTCN filetype
+au BufRead,BufNewFile *.ttcn set filetype=ttcn


### PR DESCRIPTION
Hi,
@gustafj  would be great if you merge this change to master as base fork is higher in google results and @radhus change can probably save some time. Additionally, is it possible to add also `*.ttcn3` pattern? I encounter exactly that file naming convention for TTCN3.
